### PR TITLE
Fixed FlowMods and function handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,21 @@
+import struct
 from kytos.core import KytosEvent, KytosNApp, log
 from kytos.core.helpers import listen_to
 from pyof.foundation.network_types import Ethernet, EtherType, IPv4
 from pyof.v0x04.common.action import ActionOutput
-from pyof.v0x04.common.flow_match import Match
-from pyof.v0x04.common.port import Port, PortNo
+from pyof.v0x04.common.flow_match import (
+    Match,
+    OxmClass,
+    OxmOfbMatchField,
+    MatchType,
+    OxmTLV,
+)
+from pyof.v0x04.common.flow_instructions import (
+    InstructionApplyAction,
+)
+from pyof.v0x04.common.port import PortNo
 from pyof.v0x04.controller2switch.flow_mod import FlowMod, FlowModCommand
 from pyof.v0x04.controller2switch.packet_out import PacketOut
-
-from napps.krishna4041.of_l3ls import settings
 
 
 class Main(KytosNApp):
@@ -17,25 +25,46 @@ class Main(KytosNApp):
     def execute(self):
         pass
 
-    # @listen_to('kytos/core.switch.new')
-    # def create_switching_table(self, event):
-    #     switch = event.content['switch']
-    #     switch.l3_table = {}
+    @listen_to("kytos/of_core.handshake.completed")
+    def create_switching_table(self, event):
+        switch = event.content["switch"]
+        switch.l3_table = {}
 
-    #     arp_flow_mod = FlowMod()
-    #     arp_flow_mod.command = FlowModCommand.OFPFC_ADD
-    #     arp_flow_mod.match = Match()
-    #     arp_flow_mod.match.dl_type = EtherType.ARP
-    #     # arp_flow_mod.instructions = ActionOutput(port=PortNo.OFPP_FLOOD.value)
-    #     event_out = KytosEvent(name=('krishna4041/of_l3ls.messages.out.'
-    #                            'ofpt_flow_mod'),
-    #                      content={'destination': switch.connection,
-    #                               'message': arp_flow_mod})
-    #     self.controller.buffers.msg_out.put(event_out)
+        arp_flow_mod = FlowMod()
+        arp_flow_mod.command = FlowModCommand.OFPFC_ADD
+        arp_flow_mod.priority = 10000
+        oxmtlv1 = OxmTLV(
+            oxm_class=OxmClass.OFPXMC_OPENFLOW_BASIC,
+            oxm_field=OxmOfbMatchField.OFPXMT_OFB_ETH_TYPE,
+            oxm_hasmask=False,
+            oxm_value=EtherType.ARP.value.to_bytes(2, "big"),
+        )
+        match = Match(match_type=MatchType.OFPMT_OXM, oxm_match_fields=[oxmtlv1])
+        arp_flow_mod.match = match
+        action_output = ActionOutput(port=PortNo.OFPP_FLOOD)
+        instructions = [InstructionApplyAction([action_output])]
+        arp_flow_mod.instructions = instructions
+        event_out = KytosEvent(
+            name=("krishna4041/of_l3ls.messages.out." "ofpt_flow_mod"),
+            content={"destination": switch.connection, "message": arp_flow_mod},
+        )
+        self.controller.buffers.msg_out.put(event_out)
 
-    @listen_to('kytos/of_core.v0x04.messages.in.ofpt_packet_in')
+        flow_mod_miss_entry = FlowMod()
+        flow_mod_miss_entry.command = FlowModCommand.OFPFC_ADD
+        flow_mod_miss_entry.match = Match()
+        action_output = ActionOutput(port=PortNo.OFPP_CONTROLLER)
+        instructions = [InstructionApplyAction([action_output])]
+        flow_mod_miss_entry.instructions = instructions
+        event_out = KytosEvent(
+            name=("krishna4041/of_l3ls.messages.out." "ofpt_flow_mod"),
+            content={"destination": switch.connection, "message": flow_mod_miss_entry},
+        )
+        self.controller.buffers.msg_out.put(event_out)
+
+    @listen_to("kytos/of_core.v0x04.messages.in.ofpt_packet_in")
     def handle_packet_in(self, event):
-        packet_in = event.content['message']
+        packet_in = event.content["message"]
 
         ethernet = Ethernet()
         ethernet.unpack(packet_in.data.value)
@@ -44,29 +73,54 @@ class Main(KytosNApp):
             ipv4 = IPv4()
             ipv4.unpack(ethernet.data.value)
 
-            in_port = packet_in.in_port.value
+            in_port = packet_in.in_port
             switch = event.source.switch
-            switch.l3_table[ipv4.source] = in_port
-            log.info('Packet received from %s to %s.', ipv4.source,
-                     ipv4.destination)
+            dest_port = switch.l3_table.get(ipv4.destination)
+            log.info(f"Packet received from {ipv4.source} to {ipv4.destination}.")
 
-            dest_port = switch.l3_table.get(ipv4.destination, None)
-
-            if dest_port is not None:
-                log.info('%s is at port %d.', ipv4.destination, dest_port)
+            if ipv4.source not in switch.l3_table:
+                switch.l3_table[ipv4.source] = in_port
+                log.info(f"{ipv4.source} is at port {in_port}.")
                 flow_mod = FlowMod()
                 flow_mod.command = FlowModCommand.OFPFC_ADD
-                flow_mod.match = Match()
-                flow_mod.match.nw_src = ipv4.source
-                flow_mod.match.nw_dst = ipv4.destination
-                flow_mod.match.dl_type = ethernet.ether_type
-                flow_mod.actions.append(ActionOutput(port=dest_ports[0]))
-                event_out = KytosEvent(name=('krishna4041/of_l3ls.messages.out.'
-                                             'ofpt_flow_mod'),
-                                       content={'destination': event.source,
-                                                'message': flow_mod})
+                oxmtlv1 = OxmTLV(
+                    oxm_class=OxmClass.OFPXMC_OPENFLOW_BASIC,
+                    oxm_field=OxmOfbMatchField.OFPXMT_OFB_ETH_TYPE,
+                    oxm_hasmask=False,
+                    oxm_value=EtherType.IPV4.value.to_bytes(2, "big"),
+                )
+                oxmtlv2 = OxmTLV(
+                    oxm_class=OxmClass.OFPXMC_OPENFLOW_BASIC,
+                    oxm_field=OxmOfbMatchField.OFPXMT_OFB_IPV4_SRC,
+                    oxm_hasmask=False,
+                    oxm_value=struct.pack(
+                        "bbbb", *[int(val) for val in ipv4.source.split(".")]
+                    ),
+                )
+                oxmtlv3 = OxmTLV(
+                    oxm_class=OxmClass.OFPXMC_OPENFLOW_BASIC,
+                    oxm_field=OxmOfbMatchField.OFPXMT_OFB_IPV4_DST,
+                    oxm_hasmask=False,
+                    oxm_value=struct.pack(
+                        "bbbb", *[int(val) for val in ipv4.destination.split(".")]
+                    ),
+                )
+                match = Match(
+                    match_type=MatchType.OFPMT_OXM,
+                    oxm_match_fields=[oxmtlv1, oxmtlv2, oxmtlv3],
+                )
+                flow_mod.match = match
+                instructions = [InstructionApplyAction([ActionOutput(port=in_port)])]
+                flow_mod.instructions = instructions
+                event_out = KytosEvent(
+                    name=("krishna4041/of_l3ls.messages.out." "ofpt_flow_mod"),
+                    content={"destination": event.source, "message": flow_mod},
+                )
                 self.controller.buffers.msg_out.put(event_out)
-                log.info('Flow installed! Subsequent packets will be sent directly.')
+                log.info(
+                    f"Flow installed! Subsequent packets from {ipv4.source} "
+                    f"to {ipv4.destination} will be sent directly."
+                )
 
             packet_out = PacketOut()
             packet_out.buffer_id = packet_in.buffer_id
@@ -75,11 +129,10 @@ class Main(KytosNApp):
 
             port = dest_port if dest_port is not None else PortNo.OFPP_FLOOD
             packet_out.actions.append(ActionOutput(port=port))
-            event_out = KytosEvent(name=('krishna4041/of_l3ls.messages.out.'
-                                         'ofpt_packet_out'),
-                                   content={'destination': event.source,
-                                            'message': packet_out})
-
+            event_out = KytosEvent(
+                name=("krishna4041/of_l3ls.messages.out." "ofpt_packet_out"),
+                content={"destination": event.source, "message": packet_out},
+            )
             self.controller.buffers.msg_out.put(event_out)
 
     def shutdown(self):


### PR DESCRIPTION
This fixes the FlowMods and the function handlers accordingly. 

@krishna4041, in summary these are the main differences, I think it'd be great if we can also capture and point out these points in the tutorial too, I hope it helps and serve as a reference for you to continue updating the tutorials:

- I updated the `listen_to` to subscribe to `kytos/of_core.handshake.completed` otherwise it could mess up with the initial OpenFlow negotiation.
- OpenFlow1.3 switches doesn't have by default a table miss entry, so I had to add an explicit FlowMod for that. 
- I had to adapt all matches and intructions to OpenFlow1.3 accordingly. 



```
2022-06-16 16:33:24,227 - INFO [kytos.napps.kytos/of_core] (thread_pool_sb_0) Connection ('127.0.0.1', 41554), Switch 00:00:00:00:00:00:00:01: OPENFLOW HANDSHAKE COMPLETE
2022-06-16 16:33:54,054 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_1) Packet received from 10.0.0.1 to 10.0.0.2.
2022-06-16 16:33:54,055 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_1) 10.0.0.1 is at port 1.
2022-06-16 16:33:54,060 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_1) Flow installed! Subsequent packets from 10.0.0.1 to 10.0.0.2 will be sent directly.
2022-06-16 16:33:54,079 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_0) Packet received from 10.0.0.2 to 10.0.0.1.
2022-06-16 16:33:54,081 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_0) 10.0.0.2 is at port 2.
2022-06-16 16:33:54,086 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_0) Flow installed! Subsequent packets from 10.0.0.2 to 10.0.0.1 will be sent directly.
2022-06-16 16:33:55,067 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_4) Packet received from 10.0.0.1 to 10.0.0.2.
2022-06-16 16:33:55,096 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_5) Packet received from 10.0.0.2 to 10.0.0.1.
2022-06-16 16:33:56,051 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_2) Packet received from 10.0.0.1 to 10.0.0.2.
2022-06-16 16:33:56,058 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_3) Packet received from 10.0.0.2 to 10.0.0.1.
2022-06-16 16:34:13,316 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_0) Packet received from 10.0.0.1 to 10.0.0.2.
2022-06-16 16:34:13,329 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_1) Packet received from 10.0.0.2 to 10.0.0.1.
2022-06-16 16:34:14,308 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_5) Packet received from 10.0.0.1 to 10.0.0.2.
2022-06-16 16:34:14,314 - INFO [kytos.napps.krishna4041/of_l3ls] (thread_pool_sb_1) Packet received from 10.0.0.2 to 10.0.0.1.



mininet> h1 ping h2
PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data.
64 bytes from 10.0.0.2: icmp_seq=1 ttl=64 time=0.267 ms
64 bytes from 10.0.0.2: icmp_seq=2 ttl=64 time=0.111 ms
64 bytes from 10.0.0.2: icmp_seq=3 ttl=64 time=0.116 ms


❯ sudo ovs-ofctl -O OpenFlow13 dump-flows s1 --sort=priority
 cookie=0x0, duration=98.028s, table=0, n_packets=3, n_bytes=294, send_flow_rem priority=0,ip,nw_src=10.0.0.2,nw_dst=10.0.0.1 actions=output:"s1-eth1"
 cookie=0x0, duration=98.001s, table=0, n_packets=3, n_bytes=294, send_flow_rem priority=0,ip,nw_src=10.0.0.1,nw_dst=10.0.0.2 actions=output:"s1-eth2"
 cookie=0x0, duration=127.834s, table=0, n_packets=59, n_bytes=5442, send_flow_rem priority=0 actions=CONTROLLER:65535
 cookie=0xab00000000000001, duration=127.811s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```